### PR TITLE
fix(backend): fix guide average score with raw query

### DIFF
--- a/apps/backend/src/guides/guides.repository.ts
+++ b/apps/backend/src/guides/guides.repository.ts
@@ -94,17 +94,11 @@ export class GuidesRepository {
     }
 
     try {
-      const scoreResult = await this.prismaService.review.aggregate({
-        _sum: {
-          score: true,
-        },
-        _count: {
-          score: true,
-        },
-        where: {
-          guideId: guide.id,
-        },
-      });
+      const averageReviewScore = (
+        await this.prismaService.$queryRaw<{ avg: number }[]>(
+          Prisma.sql`SELECT AVG("score") FROM "Review" WHERE "guideId" = ${guide.id}`,
+        )
+      )[0].avg;
       return {
         guideId: guide.id,
         userId: guide.user.id,
@@ -112,9 +106,7 @@ export class GuidesRepository {
         lastName: guide.user.lastName,
         imageId: guide.user.imageId,
         certificateId: guide.certificateId,
-        averageReviewScore:
-          (scoreResult._sum.score?.toNumber() | 0) /
-          (scoreResult._count.score || 1),
+        averageReviewScore,
         locations: guide.GuideLocation.map((e) => e.location.locationName),
         tourStyles: guide.GuideTourStyle.map((e) => e.tourStyle.tourStyleName),
       };


### PR DESCRIPTION
## Change made

- [x] Bug fixes
- [ ] New features
- [ ] Breaking changes

## Describe what you have done

- Use raw query instead of prisma provide method due to int / float value mismatch